### PR TITLE
Actually don't allow use of nightly features

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,6 +7,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{ inputs.toolchain }}
+        rustflags: ${{ inputs.rustflags }}
         components: clippy
     - run:
         cargo clippy
@@ -17,4 +18,7 @@ on:
     inputs:
       toolchain:
         default: stable
+        type: string
+      rustflags:
+        required: false
         type: string

--- a/.github/workflows/docsrs.yml
+++ b/.github/workflows/docsrs.yml
@@ -7,9 +7,10 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: nightly
+        rustflags: -Zallow-features=
     - run: cargo doc --no-deps --workspace --all-features --locked
-    env:
-      RUSTDOCFLAGS: --cfg=docsrs -Dwarnings
+      env:
+        RUSTDOCFLAGS: --cfg=docsrs -Dwarnings
 
 on:
   workflow_call:

--- a/.github/workflows/minimal-versions.yml
+++ b/.github/workflows/minimal-versions.yml
@@ -7,6 +7,7 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{ inputs.toolchain }}
+        rustflags: ${{ inputs.rustflags }}
     - run: rustup toolchain install nightly
     - uses: taiki-e/install-action@v2
       with:
@@ -18,4 +19,7 @@ on:
     inputs:
       toolchain:
         default: stable
+        type: string
+      rustflags:
+        required: false
         type: string

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,11 +1,9 @@
-env:
-  RUSTFLAGS: -Zallow-features=
-
 jobs:
   test:
     uses: ./.github/workflows/test.yml
     with:
       toolchain: nightly
+      rustflags: -Zallow-features=
   fmt:
     uses: ./.github/workflows/fmt.yml
     with:
@@ -14,24 +12,42 @@ jobs:
     uses: ./.github/workflows/clippy.yml
     with:
       toolchain: nightly
+      rustflags: -Zallow-features=
   docsrs:
     uses: ./.github/workflows/docsrs.yml
   deny:
     uses: ./.github/workflows/deny.yml
   updates:
-    uses: ./.github/workflows/updates.yml
+    uses: ./.github/workflows/test.yml
+    with:
+      update: true
+  updates-nightly:
+    uses: ./.github/workflows/test.yml
+    with:
+      update: true
+      toolchain: nightly
+      rustflags: -Zallow-features=
   minimal-versions:
     uses: ./.github/workflows/minimal-versions.yml
   minimal-versions-nightly:
     uses: ./.github/workflows/minimal-versions.yml
     with:
       toolchain: nightly
+      rustflags: -Zallow-features=
 
   create-issue:
     name: create issue
     runs-on: ubuntu-latest
     if: failure()
-    needs: [test, fmt, clippy, deny, updates, minimal-versions]
+    needs:
+    - test
+    - fmt
+    - clippy
+    - deny
+    - updates
+    - updates-nightly
+    - minimal-versions
+    - minimal-versions-nightly
     steps:
     - uses: actions/checkout@v4
       with:
@@ -48,7 +64,15 @@ jobs:
   close-issue:
     name: close issue
     runs-on: ubuntu-latest
-    needs: [test, fmt, clippy, deny, updates, minimal-versions]
+    needs:
+    - test
+    - fmt
+    - clippy
+    - deny
+    - updates
+    - updates-nightly
+    - minimal-versions
+    - minimal-versions-nightly
     steps:
     - uses: lee-dohm/close-matching-issues@v2
       with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,11 +6,11 @@ jobs:
     with:
       skip: ${{ inputs.skip-features }}
   updates:
-    uses: ./.github/workflows/updates.yml
+    uses: ./.github/workflows/test.yml
+    with:
+      update: true
   minimal-versions:
     uses: ./.github/workflows/minimal-versions.yml
-  coverage:
-    uses: ./.github/workflows/coverage.yml
   deny:
     uses: ./.github/workflows/deny.yml
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ jobs:
     - uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: ${{ inputs.toolchain }}
+        rustflags: ${{ inputs.rustflags }}
+    - run: cargo update
+      if: ${{ inputs.update }}
     - run: cargo test --workspace --locked --all-features ${{ inputs.args }}
 
 on:
@@ -18,6 +21,12 @@ on:
       toolchain:
         default: stable
         type: string
+      rustflags:
+        required: false
+        type: string
       args:
         required: false
         type: string
+      update:
+        default: false
+        type: boolean


### PR DESCRIPTION
Environment variables don't get inherited by workflows, and setup-rust-toolchain overrides RUSTFLAGS anyway